### PR TITLE
Fix of error in comment

### DIFF
--- a/Contracts/Crowdfunding.v
+++ b/Contracts/Crowdfunding.v
@@ -56,7 +56,7 @@ transition GetFunds
   if (tag == "getfunds") && (sender == owner) =>
   blk <- && block_number;
   bal <- & balance;
-  if max_block >= blk
+  if max_block < blk
   then if goal <= bal
        then funded := true;
             send (<to -> owner, amount -> bal,


### PR DESCRIPTION
Changed >= to <, in order to match the intent of allowing funds to be retrieved after the deadline has passed, and be consistent with lines 183 and 199.